### PR TITLE
Removed Mustache.js and switched to already used Lodash.template

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
   "dependencies": {
     "bluebird": "^2.10.0",
     "lodash": "^3.10.1",
-    "mustache": "^2.1.3",
     "shelljs": "^0.5.3",
     "yargs": "^3.25.0"
   },

--- a/src/cli.js
+++ b/src/cli.js
@@ -3,7 +3,7 @@
 var _ = require('lodash');
 var yargs = require('yargs');
 
-// Message templates use https://github.com/janl/mustache.js
+// Message templates use Lodash.template with Mustache syntax
 var defaultOpts = {
     message: 'Release {{ version }}',
     tag: '{{ version }}',

--- a/src/index.js
+++ b/src/index.js
@@ -5,13 +5,15 @@ var fs = require('fs');
 var _ = require('lodash');
 var Promise = require('bluebird');
 Promise.longStackTraces();
-var Mustache = require('mustache');
 var utils = require('./utils');
 var log = utils.log;
 var cli = require('./cli');
 var getTasks = require('./tasks');
 
 function main() {
+    // Configure _.template to match Mustache template delimiters
+    _.templateSettings.interpolate = /{{([\s\S]+?)}}/g;
+
     // Ensure that we are the directory is a valid npm project
     var stats = fs.statSync('./package.json');
     if (!stats.isFile()) {
@@ -69,14 +71,14 @@ function main() {
         return tasks.gitAdd(['package.json']);
     })
     .then(function() {
-        var message = Mustache.render(opts.message, {
+        var message = _.template(opts.message)({
             version: newVersion,
             directory: opts.directory
         });
         return tasks.gitCommit(message);
     })
     .then(function() {
-        var tag = Mustache.render(opts.tag, {
+        var tag = _.template(opts.tag)({
             version: newVersion,
             directory: opts.directory
         });


### PR DESCRIPTION
Hi,

I found it too cumbersome to use Mustache alongside Lodash that already has a templating engine.
I already configured Lodash to use Mustache's syntax for no breaking change, and as such, it's just a underlying templating engine change.

Merge it if you want to, it's just a change I made alongside when looking at the code.
Thanks,
Have a great day,
Mathieu Amiot
