### PR TITLE
Give proper error message even if the stats object ends up undefined

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -20,7 +20,7 @@ function main() {
         throw new Error('Unable to locate ./package.json!');
     }
     finally {
-        if (!stats.isFile()) {
+        if (!stats || !stats.isFile()) {
             throw new Error('Unable to locate ./package.json!');
         }
     }


### PR DESCRIPTION
With node v6.6.0, the stats object returned by `fs.statSync` seems to end up undefined in case package.json is not found. This is just a little patch to give a more meaningful error message.

Before:
```
~/dev/releasor/docs ❯❯❯ releasor                                                                                                                                           master
/Users/marv/.nvm/versions/node/v6.6.0/lib/node_modules/releasor/src/index.js:23
        if (!stats.isFile()) {
                  ^

TypeError: Cannot read property 'isFile' of undefined
    at main (/Users/marv/.nvm/versions/node/v6.6.0/lib/node_modules/releasor/src/index.js:23:19)
    at Object.<anonymous> (/Users/marv/.nvm/versions/node/v6.6.0/lib/node_modules/releasor/src/index.js:166:1)
    at Module._compile (module.js:556:32)
    at Object.Module._extensions..js (module.js:565:10)
    at Module.load (module.js:473:32)
    at tryModuleLoad (module.js:432:12)
    at Function.Module._load (module.js:424:3)
    at Module.runMain (module.js:590:10)
    at run (bootstrap_node.js:394:7)
    at startup (bootstrap_node.js:149:9)
    at bootstrap_node.js:509:3
```

After:
```
~/dev/releasor/docs ❯❯❯ releasor                                                                                                                                           
/Users/marv/.nvm/versions/node/v6.6.0/lib/node_modules/releasor/src/index.js:24
            throw new Error('Unable to locate ./package.json!');
            ^

Error: Unable to locate ./package.json!
    at main (/Users/marv/.nvm/versions/node/v6.6.0/lib/node_modules/releasor/src/index.js:24:19)
    at Object.<anonymous> (/Users/marv/.nvm/versions/node/v6.6.0/lib/node_modules/releasor/src/index.js:166:1)
    at Module._compile (module.js:556:32)
    at Object.Module._extensions..js (module.js:565:10)
    at Module.load (module.js:473:32)
    at tryModuleLoad (module.js:432:12)
    at Function.Module._load (module.js:424:3)
    at Module.runMain (module.js:590:10)
    at run (bootstrap_node.js:394:7)
    at startup (bootstrap_node.js:149:9)
    at bootstrap_node.js:509:3
```